### PR TITLE
remove Zero-width space

### DIFF
--- a/ykdl/util/html.py
+++ b/ykdl/util/html.py
@@ -76,6 +76,8 @@ def get_content(url, headers=fake_headers, data=None, charset = None):
     elif content_encoding == 'deflate':
         data = undeflate(data)
 
+    # Remove character U+200B (Zero-width space)
+    data = data.replace(b'\xe2\x80\x8b', b'')
     if charset == 'ignore':
         return data
 


### PR DESCRIPTION
https://v.qq.com/x/page/c05478w159z.html
```
UnicodeEncodeError: 'gbk' codec can't encode character '\u200b' in position 46: illegal multibyte sequence
```
Windows 命令行下无法打印和传递 `U+200B`，获取的数据需要先处理一遍。