### PR TITLE
Add range fetch server for player

### DIFF
--- a/cykdl/__main__.py
+++ b/cykdl/__main__.py
@@ -113,8 +113,8 @@ def handle_videoinfo(info, index=0):
     live = info.live
     if info.extra['rangefetch']:
         info.extra['rangefetch']['down_rate'] = info.extra['rangefetch']['video_rate'][stream_id]
-        if args.proxy != 'none':
-            info.extra['rangefetch']['proxy'] = 'http://' + args.proxy
+    if args.proxy != 'none':
+        info.extra['proxy'] = 'http://' + args.proxy
     player_args = info.extra
     player_args['title'] = info.title
     if args.player:

--- a/cykdl/__main__.py
+++ b/cykdl/__main__.py
@@ -111,6 +111,8 @@ def handle_videoinfo(info, index=0):
 
     ext = info.streams[stream_id]['container']
     live = info.live
+    if args.proxy != 'none' and info.extra['rangefetch']:
+        info.extra['rangefetch']['proxy'] = 'http://' + args.proxy
     player_args = info.extra
     player_args['title'] = info.title
     if args.player:
@@ -130,6 +132,7 @@ def main():
 
     if args.proxy == 'system':
         proxy_handler = ProxyHandler()
+        args.proxy = os.environ.get('HTTP_PROXY', 'none')
     else:
         proxy_handler = ProxyHandler({
             'http': args.proxy,

--- a/cykdl/__main__.py
+++ b/cykdl/__main__.py
@@ -114,7 +114,9 @@ def handle_videoinfo(info, index=0):
     if info.extra['rangefetch']:
         info.extra['rangefetch']['down_rate'] = info.extra['rangefetch']['video_rate'][stream_id]
     if args.proxy != 'none':
-        info.extra['proxy'] = 'http://' + args.proxy
+        proxy = 'http://' + args.proxy
+        info.extra['proxy'] = proxy
+        info.extra['rangefetch']['proxy'] = proxy
     player_args = info.extra
     player_args['title'] = info.title
     if args.player:

--- a/cykdl/__main__.py
+++ b/cykdl/__main__.py
@@ -111,8 +111,10 @@ def handle_videoinfo(info, index=0):
 
     ext = info.streams[stream_id]['container']
     live = info.live
-    if args.proxy != 'none' and info.extra['rangefetch']:
-        info.extra['rangefetch']['proxy'] = 'http://' + args.proxy
+    if info.extra['rangefetch']:
+        info.extra['rangefetch']['down_rate'] = info.extra['rangefetch']['video_rate'][stream_id]
+        if args.proxy != 'none':
+            info.extra['rangefetch']['proxy'] = 'http://' + args.proxy
     player_args = info.extra
     player_args['title'] = info.title
     if args.player:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def find_packages(*tops):
 
 from ykdl.version import __version__
 
-REQ = ['m3u8', 'pycryptodome']
+REQ = ['m3u8', 'pycryptodome', 'urllib3']
 
 setup(
     name = "ykdl",

--- a/ykdl/compact.py
+++ b/ykdl/compact.py
@@ -7,8 +7,12 @@ import struct
 
 if sys.version_info[0] == 3:
     from urllib.request import Request, urlopen, HTTPSHandler, build_opener, HTTPCookieProcessor, install_opener, ProxyHandler
-    from urllib.parse import urlencode, urlparse
+    from urllib.parse import urlencode, urlparse, urlsplit, SplitResult
     from http.client import HTTPConnection
+    from http.server import HTTPStatus, BaseHTTPRequestHandler
+    import socketserver as SocketServer
+    import queue as Queue
+    import _thread as thread
     from html import unescape
     compact_str = str
     compact_bytes = bytes
@@ -26,8 +30,13 @@ if sys.version_info[0] == 3:
 else:
     from urllib2 import Request, urlopen, HTTPSHandler, build_opener, HTTPCookieProcessor, install_opener, ProxyHandler
     from urllib import urlencode
-    from urlparse import urlparse
+    from urlparse import urlparse, urlsplit, SplitResult
     from httplib import HTTPConnection
+    from BaseHTTPServer import BaseHTTPRequestHandler
+    import httplib as HTTPStatus
+    import SocketServer
+    import Queue
+    import thread
     import types
     compact_str = unicode
     def compact_bytes(string, encode):
@@ -54,6 +63,18 @@ else:
     def unescape(s):
         html_parser = HTMLParser.HTMLParser()
         return html_parser.unescape(s)
+
+# Return addrlist sequence at random, it can help create_connection function
+import socket
+import random
+
+def getaddrinfo(*args, **kwargs):
+    addrlist = _getaddrinfo(*args, **kwargs)
+    random.shuffle(addrlist)
+    return addrlist
+
+_getaddrinfo = socket.getaddrinfo
+socket.getaddrinfo = getaddrinfo
 
 try:
     struct.pack('!I', 0)

--- a/ykdl/compact.py
+++ b/ykdl/compact.py
@@ -7,7 +7,7 @@ import struct
 
 if sys.version_info[0] == 3:
     from urllib.request import Request, urlopen, HTTPSHandler, build_opener, HTTPCookieProcessor, install_opener, ProxyHandler
-    from urllib.parse import urlencode, urlparse, urlsplit, SplitResult
+    from urllib.parse import urlencode, urlparse, urlsplit
     from http.client import HTTPConnection
     from http.server import HTTPStatus, BaseHTTPRequestHandler
     import socketserver as SocketServer
@@ -30,7 +30,7 @@ if sys.version_info[0] == 3:
 else:
     from urllib2 import Request, urlopen, HTTPSHandler, build_opener, HTTPCookieProcessor, install_opener, ProxyHandler
     from urllib import urlencode
-    from urlparse import urlparse, urlsplit, SplitResult
+    from urlparse import urlparse, urlsplit
     from httplib import HTTPConnection
     from BaseHTTPServer import BaseHTTPRequestHandler
     import httplib as HTTPStatus

--- a/ykdl/extractors/qq/video.py
+++ b/ykdl/extractors/qq/video.py
@@ -249,7 +249,6 @@ class QQ(VideoExtractor):
 
         # Downloading some videos is very slow, use multithreading range fetch to speed up.
         # Only for video players now.
-        info.extra['proxy'] = 'http://127.0.0.1:8806'
         info.extra['rangefetch'] = {'first_size': 1024 * 16, 'max_size': 1024 * 32, 'threads': 10, 'video_rate': video_rate}
 
         if self.vip:

--- a/ykdl/extractors/qq/video.py
+++ b/ykdl/extractors/qq/video.py
@@ -150,8 +150,8 @@ class QQ(VideoExtractor):
             if cdn_url == 'http://video.dispatch.tc.qq.com/':
                 break
             # Not IP host.
-            if match1(cdn_url, '(^https?://[0-9\.]+/)') is None:
-                break
+            if match1(cdn_url, '(^https?://[0-9\.]+/)'):
+                continue
         dt = cdn['dt']
         if dt == 1:
             type_name = 'flv'

--- a/ykdl/extractors/qq/video.py
+++ b/ykdl/extractors/qq/video.py
@@ -13,6 +13,7 @@ import random
 import base64
 import struct
 import uuid
+import json
 
 PLAYER_PLATFORM = 11
 PLAYER_VERSION = '3.2.19.333'
@@ -92,114 +93,82 @@ def load_key():
 
 """
 
-def qq_get_final_url(url, fmt_name, type_name, br, form, fn):
-
-    content = get_content('http://vv.video.qq.com/getkey',data=compact_bytes(form, 'utf-8'), charset = 'ignore')
-    tree = ET.fromstring(content)
-
-    vkey = tree.find('./key')
-    if vkey is None:
-        return
-    else:
-        vkey = vkey.text
-
-    level = tree.find('./level').text
-    sp = tree.find('./sp').text
-
+def qq_get_final_url(url, vid, fmt_id, filename, fvkey):
     params = {
-        'stdfrom': 'v1090',
-        'type': type_name,
-        'vkey': vkey,
-        'level': level,
+        'appver': PLAYER_VERSION,
+        'otype': 'json',
         'platform': PLAYER_PLATFORM,
-        'br': br,
-        'fmt': fmt_name,
-        'sp': sp,
+        'filename': filename,
+        'vid': vid,
+        'format': fmt_id,
     }
-    form = urlencode(params)
-    return "%s?%s" % (url, form)
+
+    content = get_content('http://vv.video.qq.com/getkey?' + urlencode(params))
+    data = json.loads(match1(content, r'QZOutputJson=(.+);$'))
+
+    vkey = data.get('key')
+    if vkey is None:
+        vkey = fvkey
+
+    return "{}{}?vkey={}".format(url, filename, vkey)
 
 
 
 class QQ(VideoExtractor):
 
     name = u"腾讯视频 (QQ)"
-
     vip = None
 
-    supported_stream_types = [ 'fhd', 'shd', 'mp4', 'hd', 'sd' ]
-
-    stream_2_profile = { 'fhd': u'蓝光', 'shd': u'超清', 'mp4': u'高清mp4', 'hd': u'高清', 'flv': u'高清flv', 'sd': u'标清', 'msd':u'急速' }
-
-    stream_2_id = { 'fhd': 'BD', 'shd': 'TD', 'mp4': 'HD', 'hd': 'HD', 'flv': 'HD', 'sd': 'SD', 'msd':'LD' }
-
+    stream_2_id = { 'fhd': 'BD', 'shd': 'TD', 'hd': 'HD', 'sd': 'SD', 'msd':'LD' }
     stream_ids = ['BD', 'TD', 'HD', 'SD', 'LD']
 
 
-    def get_streams_info(self, profile='shd'):
-
-        player_pid = uuid.uuid4().hex.upper()
-
+    def get_streams_info(self):
         params = {
-            'fp2p': 1,
-            'pid': player_pid,
-            'otype': 'xml',
-            'defn': profile,
+            'otype': 'json',
             'platform': PLAYER_PLATFORM,
-            'fhdswitch': 0,
-            'charge': 0,
-            'ckey' : "",
             'vid': self.vid,
             'defnpayver': 1,
-            'encryptVer': "",
-            'speed': random.randint(512, 1024),
-            'ran': random.random(),
             'appver': PLAYER_VERSION,
-            'defaultfmt': profile,
-            'utype': -1,
-            'vids': self.vid
         }
 
-        form = urlencode(params)
-        content = get_content('http://vv.video.qq.com/getinfo',data=compact_bytes(form, 'utf-8'), charset = 'ignore')
-        if profile == 'shd' and b'<name>shd' not in content:
-            for infos in self.get_streams_info('hd'):
-                yield infos
-            return
-        else:
-            tree = ET.fromstring(content)
+        content = get_content('http://vv.video.qq.com/getinfo?' + urlencode(params))
+        data = json.loads(match1(content, r'QZOutputJson=(.+);$'))
 
-        video = tree.find('./vl/vi')
-        filename = video.find('./fn').text
-        title = video.find('./ti').text
+        video = data['vl']['vi'][0]
+        fn = video['fn']
+        title = video['ti']
+        fvkey = video['fvkey']
+        # Not to be absolutely accuracy
+        self.vip = video['iflag']
+        
 
-        cdn = video.find('./ul/ui')
-        cdn_url = cdn.find('./url').text
-        filetype = int(cdn.find('./dt').text)
-        vt = cdn.find('./vt').text
-        if filetype == 1:
+        for cdn in video['ul']['ui']:
+            cdn_url = cdn['url']
+            # Do not choose ip host
+            if match1(cdn_url, '(^https?://[0-9\.]+/)') is None:
+                break
+        dt = cdn['dt']
+        if dt == 1:
             type_name = 'flv'
-        elif filetype == 2:
+        elif dt == 2:
             type_name = 'mp4'
         else:
             type_name = 'unknown'
 
-        _num_clips = int(video.find('./cl/fc').text)
+        _num_clips = video['cl']['fc']
 
-        fmt_id = None
-        fmt_name = None
-        fmt_br = None
-        for fmt in tree.findall('./fl/fi'):
-            fmt_id = fmt.find('./id').text
-            fmt_name = fmt.find('./name').text
-            fmt_br = fmt.find('./br').text
-            size = int(fmt.find('./fs').text)
-            #sl = int(fmt.find('./sl').text)
+        for fmt in data['fl']['fi']:
+            fmt_id = fmt['id']
+            fmt_name = fmt['name']
+            fmt_cname = fmt['cname']
+            size = fmt['fs']
 
-            fns = filename.split('.')
-            fmt_id_num = int(fmt_id)
+            fns = fn.split('.')
+            fmt_id_num = fmt_id
             fmt_id_prefix = None
             num_clips = 0
+
             if fmt_id_num > 100000:
                 fmt_id_prefix = 'm'
             elif fmt_id_num > 10000:
@@ -214,57 +183,25 @@ class QQ(VideoExtractor):
             elif fns[1][0] in ('p', 'm') and not fns[1].startswith('mp'):
                 del fns[1]
 
-            #may have preformence issue when info_only
             urls =[]
 
             if num_clips == 0:
-                fn = '.'.join(fns)
-                params = {
-                    'ran': random.random(),
-                    'appver': PLAYER_VERSION,
-                    'otype': 'xml',
-                    'encryptVer': "",
-                    'platform': PLAYER_PLATFORM,
-                    'filename': fn,
-                    'vid': self.vid,
-                    'vt': vt,
-                    'charge': 0,
-                    'format': fmt_id,
-                    'cKey': "",
-                }
-
-                form = urlencode(params)
-                clip_url = '%s%s' % (cdn_url, fn)
-                urls.append(qq_get_final_url(clip_url, fmt_name, type_name, fmt_br, form, fn))
-
+                filename = '.'.join(fns)
+                url = qq_get_final_url(cdn_url, self.vid, fmt_id, filename, fvkey)
+                urls.append(url)
             else:
                 fns.insert(-1, '1')
                 for idx in range(1, num_clips+1):
                     fns[-2] = str(idx)
-                    fn = '.'.join(fns)
-                    params = {
-                        'ran': random.random(),
-                        'appver': PLAYER_VERSION,
-                        'otype': 'xml',
-                        'encryptVer': "",
-                        'platform': PLAYER_PLATFORM,
-                        'filename': fn,
-                        'vid': self.vid,
-                        'vt': vt,
-                        'charge': 0,
-                        'format': fmt_id,
-                        'cKey': "",
-                    }
-                    form = urlencode(params)
-                    clip_url = '%s%s' % (cdn_url, fn)
-                    url = qq_get_final_url(clip_url, fmt_name, type_name, fmt_br, form, fn)
+                    filename = '.'.join(fns)
+                    url = qq_get_final_url(cdn_url, self.vid, fmt_id, filename, fvkey)
                     if url:
                         urls.append(url)
                     else:
                         self.vip = True
                         break
 
-            yield title, fmt_name, type_name, urls, size
+            yield title, fmt_name, fmt_cname, type_name, urls, size
 
     def prepare(self):
         info = VideoInfo(self.name)
@@ -282,16 +219,19 @@ class QQ(VideoExtractor):
                 self.logger.warning('This video has been deleted!')
                 return info
 
-        for title, fmt_name, type_name, urls, size in self.get_streams_info():
+        for title, fmt_name, stream_profile, type_name, urls, size in self.get_streams_info():
             stream_id = self.stream_2_id[fmt_name]
-            stream_profile = self.stream_2_profile[fmt_name]
-            if not stream_id in info.stream_types:
+            if stream_id not in info.stream_types:
                 info.stream_types.append(stream_id)
                 info.streams[stream_id] = {'container': type_name, 'video_profile': stream_profile, 'src' : urls, 'size': size}
         info.stream_types = sorted(info.stream_types, key = self.stream_ids.index)
         info.title = title
 
+        # Downloading vip videos is very slow (playable part), use multithreading range fetch to speed up.
+        # Only for video players.
         if self.vip:
+            info.extra['proxy'] = 'http://127.0.0.1:8806'
+            info.extra['rangefetch'] = {'first_size': 1024 * 16, 'max_size': 1024 * 32, 'threads': 20}
             self.logger.warning('This is a VIP video!')
 
         return info

--- a/ykdl/extractors/qq/video.py
+++ b/ykdl/extractors/qq/video.py
@@ -143,15 +143,21 @@ class QQ(VideoExtractor):
         # Not to be absolutely accuracy.
         self.vip = video['iflag']
 
+        # Priority for range fetch.
+        cdn_url_1 = cdn_url_2 = cdn_url_3 = None
         for cdn in video['ul']['ui']:
-            # Priority for range fetch.
             cdn_url = cdn['url']
             # 'video.dispatch.tc.qq.com' supported keep-alive link.
             if cdn_url == 'http://video.dispatch.tc.qq.com/':
+                cdn_url_1 = cdn_url
                 break
-            # Not IP host.
+            # IP host.
             if match1(cdn_url, '(^https?://[0-9\.]+/)'):
-                continue
+                cdn_url_3 = cdn_url
+            else:
+                cdn_url_2 = cdn_url
+        cdn_url = cdn_url_1 or cdn_url_2 or cdn_url_3 
+
         dt = cdn['dt']
         if dt == 1:
             type_name = 'flv'

--- a/ykdl/extractors/qq/video.py
+++ b/ykdl/extractors/qq/video.py
@@ -134,7 +134,6 @@ class QQ(VideoExtractor):
 
         content = get_content('http://vv.video.qq.com/getinfo?' + urlencode(params))
         data = json.loads(match1(content, r'QZOutputJson=(.+);$'))
-        print(data)
 
         video = data['vl']['vi'][0]
         fn = video['fn']

--- a/ykdl/extractors/qq/video.py
+++ b/ykdl/extractors/qq/video.py
@@ -123,17 +123,24 @@ class QQ(VideoExtractor):
     stream_ids = ['BD', 'TD', 'HD', 'SD', 'LD']
 
 
-    def get_streams_info(self):
+    def get_streams_info(self, profile='shd'):
         params = {
             'otype': 'json',
             'platform': PLAYER_PLATFORM,
             'vid': self.vid,
             'defnpayver': 1,
             'appver': PLAYER_VERSION,
+            'defn': profile,
         }
 
         content = get_content('http://vv.video.qq.com/getinfo?' + urlencode(params))
-        data = json.loads(match1(content, r'QZOutputJson=(.+);$'))
+        if profile == 'shd' and '"name":"fhd"' not in content:
+            for infos in self.get_streams_info('hd'):
+                yield infos
+            return
+        else:
+            data = json.loads(match1(content, r'QZOutputJson=(.+);$'))
+        self.logger.debug('data: ' + str(data))
 
         video = data['vl']['vi'][0]
         fn = video['fn']

--- a/ykdl/extractors/qq/video.py
+++ b/ykdl/extractors/qq/video.py
@@ -140,13 +140,16 @@ class QQ(VideoExtractor):
         title = video['ti']
         td = float(video['td'])
         fvkey = video['fvkey']
-        # Not to be absolutely accuracy
+        # Not to be absolutely accuracy.
         self.vip = video['iflag']
-        
 
         for cdn in video['ul']['ui']:
+            # Priority for range fetch.
             cdn_url = cdn['url']
-            # Do not choose ip host
+            # 'video.dispatch.tc.qq.com' supported keep-alive link.
+            if cdn_url == 'http://video.dispatch.tc.qq.com/':
+                break
+            # Not IP host.
             if match1(cdn_url, '(^https?://[0-9\.]+/)') is None:
                 break
         dt = cdn['dt']
@@ -232,13 +235,12 @@ class QQ(VideoExtractor):
         info.title = title
 
         # Downloading some videos is very slow, use multithreading range fetch to speed up.
-        # Auto-adjust threads number be supported.
-        # Only for video players.
+        # Only for video players now.
         info.extra['proxy'] = 'http://127.0.0.1:8806'
         info.extra['rangefetch'] = {'first_size': 1024 * 16, 'max_size': 1024 * 32, 'threads': 10, 'video_rate': video_rate}
 
         if self.vip:
-            info.extra['rangefetch']['threads'] = 20
+            info.extra['rangefetch']['threads'] = 14
             self.logger.warning('This is a VIP video!')
 
         return info

--- a/ykdl/util/rangefetch_server.py
+++ b/ykdl/util/rangefetch_server.py
@@ -88,6 +88,7 @@ class RangeFetch():
     expect_begin = 0
     _stopped = -1
     proxy = None
+    http = None
 
     down_rate_min = 1024 * 160 # B/s
     down_rate_max = 1024 * 360
@@ -113,10 +114,10 @@ class RangeFetch():
         self.delay_star_size = self.delay_cache_size * 2
         self.max_threads = min(self.threads * 2, 24)
 
-        if self.proxy:
-            self.http = urllib3.ProxyManager(self.proxy, maxsize=self.max_threads)
+        if self.http is None and self.proxy:
+            self.__class__.http = urllib3.ProxyManager(self.proxy, maxsize=self.max_threads)
         else:
-            self.http = urllib3.PoolManager(maxsize=self.max_threads)
+            self.__class__.http = urllib3.PoolManager(maxsize=self.max_threads)
 
         self.firstrange = range_start, range_start + self.first_size - 1
         self.response = self.rangefetch(*self.firstrange)
@@ -227,7 +228,7 @@ class RangeFetch():
 
             if check_size > self.check_size:
                 pres_time = time()
-                down_rate = check_size / (pres_time - speedtest['prev_time'])
+                down_rate = check_size / (pres_time - speedtest['prev_time'] + 0.1)
 
                 if down_rate < self.down_rate_min:
                     threads_adjust = self.down_rate_min * 2 // down_rate

--- a/ykdl/util/rangefetch_server.py
+++ b/ykdl/util/rangefetch_server.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Multithreading range fetch via proxy server,
+# use urllib3 to reusing connections.
+
+from logging import getLogger
+from ykdl.compact import (
+    Queue, thread, urlsplit, SplitResult,
+    HTTPStatus, BaseHTTPRequestHandler, SocketServer
+    )
+
+import urllib3
+import re
+import socket
+from time import sleep
+
+logger = getLogger('RangeFetch')
+
+class LocalTCPServer(SocketServer.ThreadingTCPServer):
+
+    request_queue_size = 2
+    allow_reuse_address = True
+
+    def server_bind(self):
+        sock = self.socket
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, True)
+        self.RequestHandlerClass.bufsize = sock.getsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF)
+        SocketServer.TCPServer.server_bind(self)
+
+    def server_close(self):
+        self.shutdown()
+        self.socket.close()
+
+class RangeFetchHandler(BaseHTTPRequestHandler):
+    '''
+    HTTP Handler.
+
+    :property scheme:
+        Set the value to 'https' can connect remote server ues https.
+    '''
+
+    protocol_version = 'HTTP/1.1'
+    scheme = 'http'
+
+    def do_CONNECT(self):
+        self.send_error(HTTPStatus.NOT_IMPLEMENTED,
+            'Range fetch via HTTPS can not be supported!')
+
+    def do_GET(self):
+        url_parts = urlsplit(self.path)
+        self.host = netloc = self.headers.get('Host') or url_parts.netloc
+        self.url = SplitResult(self.scheme, netloc, url_parts.path, url_parts.query, '').geturl()
+        
+        need_rangefetch = not ('range=' in url_parts.query or
+                               'live=1' in url_parts.query or
+                               'range/' in url_parts.path
+                               )
+        range_start = range_end = 0
+
+        if need_rangefetch:
+            need_rangefetch = 1
+            request_range = self.headers.get('Range')
+            if request_range is not None:
+                request_range = getbytes(request_range)
+                if request_range:
+                    range_start, range_end, range_other = request_range.group(1, 2, 3)
+                    if not range_start or range_other:
+                        # Unable to process unspecified start range or discontinuous range
+                        range_start = 0
+                        need_rangefetch = 0
+                    else:
+                        range_start = int(range_start)
+                        if range_end:
+                            range_end = int(range_end)
+        else:
+            need_rangefetch = -1
+
+        if need_rangefetch is 1:
+            RangeFetch(self, range_start, range_end).fetch()
+        else:
+            self.send_error(HTTPStatus.INTERNAL_SERVER_ERROR,
+                'Range fetch can not be finished, url: %s' %  self.url)
+
+class RangeFetch():
+
+    expect_begin = 0
+    _stopped = False
+    proxy = None
+
+    first_size = 1024 * 32
+    max_size = 1024 * 32
+    threads = 8
+    delay = 0.5
+
+    def __init__(self, handler, range_start, range_end):
+        self.handler = handler
+        self.bufsize = handler.bufsize
+        self.write = handler.wfile.write
+        self.url = handler.url
+        self.headers = dict((k.title(), v) for k, v in handler.headers.items()
+                           if not k.title().startswith('Proxy-'))
+        # Set 'keep-alive'
+        self.headers['Connection'] = 'keep-alive'
+
+        self.range_start = range_start
+        self.range_end = range_end
+
+        self.delay_star_size = self.max_size * self.threads
+        self.delay_cache_size = self.delay_star_size * 2
+
+        if self.proxy:
+            self.http = urllib3.ProxyManager(self.proxy, maxsize=self.threads + 2)
+        else:
+            self.http = urllib3.PoolManager(maxsize=self.threads + 2)
+        self.firstrange = range_start, range_start + self.first_size - 1
+        self.response = self.rangefetch(*self.firstrange)
+
+        self.data_queue = Queue.PriorityQueue()
+        self.range_queue = Queue.PriorityQueue()
+
+    def rangefetch(self, range_start, range_end, max_tries=3):
+        tries= 0
+        headers = self.headers.copy()
+        headers['Range'] = 'bytes=%d-%d' % (range_start, range_end)
+
+        while True:
+            response = self.http.request('GET', self.url, headers=headers, redirect=False, preload_content=False)
+
+            redirect_location = response.get_redirect_location()
+            if redirect_location:
+                if not redirect_location.startswith(('http://', 'https://', '/')) :
+                    redirect_location = '/' + redirect_location
+                if redirect_location[0] == '/':
+                    redirect_location = '%s://%s%s' % (self.handler.scheme, self.handler.host, redirect_location)
+                self.url = redirect_location
+                response.read()
+                response.release_conn()
+                continue
+
+            if response.status == 206:
+                return response
+
+            tries += 1
+            if tries >= max_tries:
+                break
+            sleep(2)
+
+    def fetch(self):
+        response_status = self.response.status
+        response_headers = self.response.headers
+
+        start, end, length = tuple(int(x) for x in getrange(response_headers['Content-Range']).group(1, 2, 3))
+        content_length = end + 1 - start
+        _end = length - 1
+        if start == 0 and self.range_end in (0, _end) and 'Range' not in self.headers:
+            response_status = 200
+            response_headers['Content-Length'] = str(length)
+            range_end = _end
+            del response_headers['Content-Range']
+        else:
+            range_end = self.range_end or _end
+            response_headers['Content-Range'] = 'bytes %s-%s/%s' % (start, range_end, length)
+            length = range_end + 1
+            response_headers['Content-Length'] = str(length - start)
+
+        self.handler.send_response_only(response_status)
+        for kv in response_headers.items():
+            self.handler._headers_buffer.append(('%s: %s\r\n' % kv).encode())
+        self.handler.end_headers()
+
+        data_queue = self.data_queue
+        range_queue = self.range_queue
+
+        a = end + 1
+        b = end
+        n = (length - a) // self.max_size
+        for _ in range(n):
+            b += self.max_size
+            range_queue.put((a, b))
+            a = b + 1
+        if length > a:
+            range_queue.put((a, length - 1))
+
+        for i in range(self.threads):
+            spawn_later(self.delay * i, self.__fetchlet)
+
+        has_peek = hasattr(data_queue, 'peek')
+        peek_timeout = 30
+        self.expect_begin = start
+
+        while self.expect_begin < length:
+            try:
+                if has_peek:
+                    begin, data = data_queue.peek(timeout=peek_timeout)
+                    if self.expect_begin == begin:
+                        data_queue.get()
+                    elif self.expect_begin < begin:
+                        sleep(0.1)
+                        continue
+                    else:
+                        logger.error('error: begin(%r) < expect_begin(%r), exit.'% (begin, self.expect_begin))
+                        break
+                else:
+                    begin, data = data_queue.get(timeout=peek_timeout)
+                    if self.expect_begin == begin:
+                        pass
+                    elif self.expect_begin < begin:
+                        data_queue.put((begin, data))
+                        sleep(0.1)
+                        continue
+                    else:
+                        logger.error('error: begin(%r) < expect_begin(%r), exit.'% (begin, self.expect_begin))
+                        break
+            except Queue.Empty:
+                logger.error('data_queue peek timedout break')
+                break
+            try:
+                self.write(data)
+                self.expect_begin += len(data)
+            except Exception as e:
+                logger.warning('disconnected: %r, %r' % (self.url, e))
+                break
+        self._stopped = True
+
+    def __fetchlet(self):
+        data_queue = self.data_queue
+        range_queue = self.range_queue
+
+        while True:
+            if self._stopped:
+                return
+
+            if self.response:
+                response, self.response = self.response, None
+                start, end = self.firstrange
+            else:
+                try:
+                    start, end = range_queue.get(timeout=1)
+                except Queue.Empty:
+                    return
+                while ((start - self.expect_begin) > self.delay_star_size and
+                        data_queue.qsize() * self.bufsize > self.delay_cache_size):
+                    if self._stopped:
+                        return
+                    sleep(0.1)
+     
+                response = self.rangefetch(start, end)
+                if response is None:
+                    range_queue.put((start, end))
+                    continue
+
+            try:
+                data = response.read(self.bufsize)
+                while data:
+                    if self._stopped:
+                        return
+                    data_queue.put((start, data))
+                    start += len(data)
+                    data = response.read(self.bufsize)
+            except Exception as e:
+                response.close()
+            else:
+                response.release_conn()
+            logger.debug('receive %d bytes' % start)
+
+            if start < end + 1:
+                logger.warning('retry %d-%d' % (start, end))
+                range_queue.put((start, end))
+                continue
+
+getbytes = re.compile(r'^bytes=(\d*)-(\d*)(,..)?').search
+getrange = re.compile(r'^bytes (\d+)-(\d+)/(\d+)').search
+
+def spawn_later(seconds, target, *args, **kwargs):
+    def wrap(*args, **kwargs):
+        sleep(seconds)
+        target(*args, **kwargs)
+    thread.start_new_thread(wrap, args, kwargs)
+
+
+def start_new_server(bind='', port=8806, first_size=None, max_size=None,
+                     threads=None, scheme=None, proxy=None):
+    if first_size:
+        RangeFetch.first_size = first_size
+    if max_size:
+        RangeFetch.max_size = max_size
+    if threads:
+        RangeFetch.threads = threads
+    if proxy:
+        RangeFetch.proxy = proxy
+    if scheme:
+        RangeFetchHandler.scheme = scheme
+    new_server = LocalTCPServer((bind, port), RangeFetchHandler)
+    thread.start_new_thread(new_server.serve_forever, ())
+    sleep(0.1)
+    return new_server

--- a/ykdl/util/rangefetch_server.py
+++ b/ykdl/util/rangefetch_server.py
@@ -120,7 +120,7 @@ class RangeFetch():
 
         self.range_start = range_start
         self.range_end = range_end
-        self.delay_cache_size = self.max_size * self.threads * 2
+        self.delay_cache_size = self.max_size * self.threads * 4
         self.delay_star_size = self.delay_cache_size * 2
         self.max_threads = min(self.threads * 2, 24)
 
@@ -156,6 +156,7 @@ class RangeFetch():
 
             tries += 1
             if tries >= max_tries:
+                logger.debug('request %d-%d fail' % (range_start, range_end))
                 break
             sleep(2)
 
@@ -372,7 +373,7 @@ def start_new_server(bind='', port=8806, first_size=None, max_size=None,
         RangeFetch.threads = threads
     if down_rate:
         RangeFetch.down_rate_min = int(down_rate * 2)
-        RangeFetch.down_rate_max = RangeFetch.down_rate_min + max(down_rate, 1024 * 100)
+        RangeFetch.down_rate_max = RangeFetch.down_rate_min + min(max(down_rate, 1024 * 100), 1024 * 200)
     if proxy:
         RangeFetch.proxy = proxy
     if scheme:

--- a/ykdl/util/rangefetch_server.py
+++ b/ykdl/util/rangefetch_server.py
@@ -88,10 +88,10 @@ class RangeFetchHandler(BaseHTTPRequestHandler):
         return '%s://%s%s' % (self.scheme, self.netloc, get_path(url))
 
     def join_redirect(self, url):
-        if url.find('://', 3, 12):
-            return url
-        else:
+        if url.find('://', 3, 12) < 0:
             return self.join_path(url)
+        else:
+            return url
 
 class RangeFetch():
 
@@ -355,7 +355,7 @@ def spawn_later(seconds, target, *args, **kwargs):
     thread.start_new_thread(wrap, args, kwargs)
 
 def get_path(url):
-    if url.find('://', 3, 12):
+    if not url.find('://', 3, 12) < 0:
         url = url[url.find('/', 12):]
     if url[0] != '/':
         url = '/' + url

--- a/ykdl/util/rangefetch_server.py
+++ b/ykdl/util/rangefetch_server.py
@@ -124,10 +124,11 @@ class RangeFetch():
         self.delay_star_size = self.delay_cache_size * 2
         self.max_threads = min(self.threads * 2, 24)
 
+        timeout = urllib3.Timeout(connect=1, read=2)
         if self.http is None and self.proxy:
-            self.__class__.http = urllib3.ProxyManager(self.proxy, maxsize=self.max_threads)
+            self.__class__.http = urllib3.ProxyManager(self.proxy, timeout=timeout, maxsize=self.max_threads)
         else:
-            self.__class__.http = urllib3.PoolManager(maxsize=self.max_threads)
+            self.__class__.http = urllib3.PoolManager(timeout=timeout, maxsize=self.max_threads)
 
         self.firstrange = range_start, range_start + self.first_size - 1
         self.response = self.rangefetch(*self.firstrange)
@@ -156,7 +157,7 @@ class RangeFetch():
 
             tries += 1
             if tries >= max_tries:
-                logger.debug('request %d-%d fail' % (range_start, range_end))
+                logger.warning('request %d-%d fail' % (range_start, range_end))
                 break
             sleep(2)
 

--- a/ykdl/util/wrap.py
+++ b/ykdl/util/wrap.py
@@ -31,21 +31,25 @@ def launch_player(player, urls, **args):
             cmd += ['--force-media-title', args['title']]
         if args['header']:
             cmd += ['--http-header-fields', args['header']]
-
-    cmd += list(urls)
-
-    if args['proxy']:
+    
+    if args['rangefetch']:
+        cmd += ['http://127.0.0.1:8806/' + url for url in urls]
         env = os.environ.copy()
-        env['HTTP_PROXY'] = args['proxy']
-        if args['rangefetch']:
-            from ykdl.util.rangefetch_server import start_new_server
-            new_server = start_new_server(**args['rangefetch'])
-            subprocess.call(cmd, env=env)
-            new_server.server_close()
-        else:
-            subprocess.call(cmd, env=env)
+        env.pop('HTTP_PROXY', None)
+        env.pop('HTTPS_PROXY', None)
+        from ykdl.util.rangefetch_server import start_new_server
+        new_server = start_new_server(**args['rangefetch'])
+        subprocess.call(cmd, env=env)
+        new_server.server_close()
     else:
-        subprocess.call(cmd)
+        cmd += list(urls)
+        if args['proxy']:
+            env = os.environ.copy()
+            env['HTTP_PROXY'] = args['proxy']
+            env['HTTPS_PROXY'] = args['proxy']
+            subprocess.call(cmd, env=env)
+        else:
+            subprocess.call(cmd)
 
 def launch_ffmpeg(basename, ext, lenth):
     #build input

--- a/ykdl/videoinfo.py
+++ b/ykdl/videoinfo.py
@@ -17,7 +17,7 @@ class VideoInfo():
         self.stream_types = []
         self.streams = {}
         self.live = live
-        self.extra = {"ua": "", "referer": "", "header": ""}
+        self.extra = {"ua": "", "referer": "", "header": "", "proxy": "", "rangefetch": ""}
 
     def print_stream_info(self, stream_id, show_all = False):
         stream = self.streams[stream_id]


### PR DESCRIPTION
这是一个使用多线程来加速下载的代理服务器，主要针对某些速度超级慢的视频，调用参数如下：
https://github.com/zhangn1985/ykdl/blob/7386ddd63f8202f57faa48c24eff2edeaa8da3cc/ykdl/extractors/qq/video.py#L233-L234

暂时只用于播放器，参数可以根据情况调整；
支持使用前置代理，也就是 `--proxy` 也同样作用于 range fetch 代理服务器；
由于是通过改变环境变量来设置播放器代理， MPV 以外的播放器可能不支持。（MPV 大法好 :+1:  ）

要注意的地方是，因为是用代理来实现的，所以无法直接支持 https 链接。
当要使用 https 链接时，先把链接替换为 http，再在 rangefetch 参数字典中增加 `'scheme': 'https'` 即可。

远程 fetch 使用 urllib3 实现，看中它的链接重用，消耗较少。
如果觉得不合适，可以重写一个相对简单的，这就比较花时间了。