### PR TITLE
embed extractor: refactor video_info structure

### DIFF
--- a/ykdl/extractors/acfun.py
+++ b/ykdl/extractors/acfun.py
@@ -12,14 +12,20 @@ class Acfun(EmbedExtractor):
     name = u'ACfun 弹幕视频网'
 
     def prepare(self):
-
         html = get_content(self.url)
+        pageInfo = json.loads(match1(html, u'<script>var pageInfo = (.+?)</script>'))
+        title = pageInfo['title']
 
-        sourceVid = match1(html, "data-vid=\"([a-zA-Z0-9=]+)\" data-")
+        sourceVid = match1(self.url, 'vid=([a-zA-Z0-9=]+)')
+        if not sourceVid:
+            sourceVid = match1(html, "data-vid=\"([a-zA-Z0-9=]+)\" data-")
 
         data = json.loads(get_content('http://www.acfun.cn/video/getVideo.aspx?id={}'.format(sourceVid)))
         sourceType = data['sourceType']
         sourceId = data['sourceId']
+        sub_title = data['title']
+        if sub_title != 'Part1' or len(pageInfo['videoList']) > 1:
+            title = '{} - {}'.format(title, sub_title)
 
         if sourceType == 'zhuzhan':
             sourceType = 'acorig'
@@ -32,16 +38,20 @@ class Acfun(EmbedExtractor):
         elif sourceType == 'qq':
             sourceType = 'qq.video'
 
-        self.video_info=(sourceType, sourceId)
+        self.video_info['site'] = sourceType
+        self.video_info['vid'] = sourceId
+        self.video_info['title'] = title
 
     def prepare_playlist(self):
 
         html = get_content(self.url)
 
-        videos = matchall(html, ['href="(\/v\/[a-zA-Z0-9_]+)" title="'])
+        videos = matchall(html, ['href="(/v/[a-zA-Z0-9_]+)" title="'])
 
         for v in videos:
-            next_url = "http://www.acfun.cn/{}".format(v)
-            self.video_info_list.append(('acfun', next_url))
+            next_url = "http://www.acfun.cn{}".format(v)
+            video_info = self.new_video_info()
+            video_info['url'] = next_url
+            self.video_info_list.append(video_info)
 
 site = Acfun()

--- a/ykdl/extractors/dilidili.py
+++ b/ykdl/extractors/dilidili.py
@@ -3,11 +3,10 @@
 
 from ykdl.util.html import get_content
 from ykdl.util.match import match1
-from ykdl.extractor import VideoExtractor
+from ykdl.embedextractor import EmbedExtractor
 from ykdl.videoinfo import VideoInfo
-from ykdl.common import url_to_module
 
-class Dilidili(VideoExtractor):
+class Dilidili(EmbedExtractor):
     name = u'嘀哩嘀哩（dilidili）'
 
     def build_videoinfo(self, title, ext, *urls):
@@ -24,7 +23,7 @@ class Dilidili(VideoExtractor):
                 'size' : 0
             }
             channel += 1
-        return info
+        self.video_info['info'] = info
     
     def prepare(self):
         html = get_content(self.url)
@@ -39,14 +38,12 @@ class Dilidili(VideoExtractor):
         
             # Dilidili hosts this video itself
             if ext in ('mp4', 'flv', 'f4v', 'm3u', 'm3u8'):
-                return self.build_videoinfo(title, ext, source_url)
+                self.build_videoinfo(title, ext, source_url)
         
             # It is an embedded video from other websites
             else:
-                site, new_url = url_to_module(source_url)
-                info_embedded = site.parser(new_url)
-                info_embedded.title = title
-                return info_embedded
+                self.video_info['url'] = source_url
+                self.video_info['title'] = title
 
         # Second type, user-uploaded videos
         # http://www.dilidili.wang/huiyuan/76983/
@@ -56,7 +53,7 @@ class Dilidili(VideoExtractor):
             video_url = match1(html, r'var main = "(.+?)"')
             video_url_full = '/'.join(player_url.split('/')[0:3]) + video_url
             ext = video_url.split('?')[0].split('.')[-1]
-            return self.build_videoinfo(title, ext, video_url_full)
+            self.build_videoinfo(title, ext, video_url_full)
 
 
 site = Dilidili()

--- a/ykdl/extractors/generalembed.py
+++ b/ykdl/extractors/generalembed.py
@@ -97,19 +97,26 @@ class GeneralEmbed(EmbedExtractor):
     name = u"GeneralEmbed (通用嵌入视频)"
 
     def prepare_playlist(self):
+
+        def append_video_info(site, vid):
+            video_info = self.new_video_info()
+            video_info['site'] = site
+            video_info['vid'] = vid
+            self.video_info_list.append(video_info)
+
         content = get_content(self.url)
 
         vids = matchall(content, youku_embed_patterns)
         for vid in vids:
-            self.video_info_list.append(('youku',vid))
+            append_video_info('youku',vid)
 
         vids = matchall(content, qq_embed_patterns)
         for vid in vids:
-            self.video_info_list.append(('qq.video',vid))
+            append_video_info('qq.video',vid)
 
         vids = matchall(content, sohu_embed_patterns)
         for vid in vids:
-            self.video_info_list.append(('sohu.my',vid))
+            append_video_info('sohu.my',vid)
 
         urls = matchall(content, ku6_embed_url)
         for url in urls:
@@ -117,42 +124,44 @@ class GeneralEmbed(EmbedExtractor):
             flashvars = matchall(html, ['vid=([^&]+)', 'style=([^&]+)', 'sn=([^&]+)'])
             data = json.loads(get_content('http://v.ku6vms.com/phpvms/player/forplayer/vid/{}/style/{}/sn/{}'.format(flashvars[0], flashvars[1],flashvars[2])))
             vid = data['ku6vid']
-            self.video_info_list.append(('ku6',vid))
+            append_video_info('ku6',vid)
+
         vids = matchall(content, ku6_embed_patterns)
         for v in vids:
-            self.video_info_list.append(('ku6', v))
+            append_video_info('ku6', v)
+
         vids = matchall(content, netease_embed_patterns)
         for v in vids:
-            self.video_info_list.append(('netease.video', v))
+            append_video_info('netease.video', v)
 
         vids = matchall(content, iqiyi_embed_patterns)
         for v in vids:
             videoid, tvid = v
-            self.video_info_list.append(('iqiyi', (tvid, videoid)))
+            append_video_info('iqiyi', (tvid, videoid))
 
         vids = matchall(content, lecloud_embed_patterns)
         for v in vids:
             uu, vu = v
-            self.video_info_list.append(('le.letvcloud', (vu, uu)))
+            append_video_info('le.letvcloud', (vu, uu))
 
         vids = matchall(content, ifeng_embed_patterns)
         for v in vids:
             v  = v.split('&')[0]
-            self.video_info_list.append(('ifeng.news', v))
+            append_video_info('ifeng.news', v)
 
         vids = matchall(content, weibo_embed_patterns)
         for v in vids:
-            self.video_info_list.append(('weibo','http://weibo.com/p/' + v))
+            append_video_info('weibo', 'http://weibo.com/p/' + v)
 
         vids = matchall(content, sina_embed_patterns)
         for v in vids:
             v  = v.split('&')[0]
-            self.video_info_list.append(('sina.video', v))
+            append_video_info('sina.video', v)
 
         vids = matchall(content, bilibili_embed_patterns)
         for v in vids:
             v = "https://www.bilibili.com/video/av{}".format(v)
-            self.video_info_list.append(('bilibili.video', v))
+            append_video_info('bilibili.video', v)
 
 
         vids = matchall(content, dilidili_embed_patterns)
@@ -165,7 +174,7 @@ class GeneralEmbed(EmbedExtractor):
             elif site =='yun':
                 site = 'le.letvcloud'
                 v = v.split(':')
-            self.video_info_list.append((site, v))
+            append_video_info(site, v)
 
         tmp = []
         for v in self.video_info_list:


### PR DESCRIPTION
把 video_info 类型改成 Dict，支持传入：
1. `site` 和 `vid` ：用作解析内嵌视频的参数
1. `url` ：同上，但不能同时起作用
1. `title` 、 `artist`和 `extra` ：用于更新解析结果的同名属性
1. `info` ：作为兼容，可直接传递最终的视频解析结果

增加一个静态函数 `new_video_info`，固定返回 `{'extra': {}}`，用作 `video_info` 的初始值。

简单测试了一下 Win + python3。