### PR TITLE
JSEngine: fix context broken

### DIFF
--- a/ykdl/util/jsengine_chakra.py
+++ b/ykdl/util/jsengine_chakra.py
@@ -28,7 +28,6 @@ class ChakraHandle():
 
         context = _ctypes.c_void_p()
         chakra.JsCreateContext(runtime, point(context))
-        chakra.JsSetCurrentContext(context)
 
         self.__runtime = runtime
         self.__context = context
@@ -60,7 +59,9 @@ class ChakraHandle():
                             chakra internal error code
         """
 
+        # TODO: may need a thread lock, if running multithreading
         chakra = self.__chakra
+        chakra.JsSetCurrentContext(self.__context)
         # make sure they are unicode string
         if hasattr(script, 'decode'):
             script = script.decode('utf8')


### PR DESCRIPTION
1. ChakraJSEngine has no separate context, and can not return null value.
1. ExternalJSEngine forgot the old codes that has already been run.

ExternalJSEngine 的 bug 是从 PyExecJS 引入的。
修改后简单试了下，没有发现更多的问题。
线程锁估计用不着，就只是备注在注释中。

顺便把格式整理了。