### PR TITLE
better cdn

### DIFF
--- a/ykdl/extractors/douyu/live.py
+++ b/ykdl/extractors/douyu/live.py
@@ -89,7 +89,7 @@ class Douyutv(VideoExtractor):
             'did': did,
             'tt': tt,
             'sign': match1(ub98484234, 'sign=(\w{32})'),
-            'cdn': '',
+            'cdn': 'ws-h5',
             'iar': 0,
             'ive': 0
         }


### PR DESCRIPTION
cdn=None 返回备用线路，但斗鱼备用线路有dns负载均衡配置bug，全国都可能返回上海IP