### PR TITLE
Windows: add ANSI escape support for shell output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,10 @@ def find_packages(*tops):
 from ykdl.version import __version__
 
 REQ = ['m3u8', 'pycryptodome', 'urllib3']
+EXT = {}
+if os.name == 'nt':
+    EXT['ansi-escape'] = ['colorama']
+
 
 setup(
     name = "ykdl",
@@ -38,6 +42,7 @@ setup(
     packages = find_packages('ykdl', 'cykdl'),
     requires = REQ,
     install_requires = REQ,
+    extras_require = EXT,
     platforms = 'any',
     zip_safe = True,
     package_data = {

--- a/ykdl/__init__.py
+++ b/ykdl/__init__.py
@@ -1,59 +1,42 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*
 
-from __future__ import print_function
-from .util.log import ColorHandler
-import logging
-
 import sys
 
-if sys.version_info[0] == 3:
-    if sys.platform.startswith('win') and sys.version_info[1] < 6:
+if sys.platform.startswith('win'):
+    # hack sys.stdout in Windows cmd shell
+    if sys.version_info[0] < 3:
+        class filewrapper(object):
+            def __init__(self, file, encoding=None, errors='ignore'):
+                object.__setattr__(self, 'wrappedfile', file)
+                object.__setattr__(self, 'encoding', encoding or file.encoding)
+                object.__setattr__(self, 'errors', errors)
+
+            def __getattr__(self, name):
+                return getattr(self.wrappedfile, name)
+
+            def __setattr__(self, name, value):
+                setattr(self.wrappedfile, name, value)
+
+            def write(self, s):
+                if isinstance(s, unicode):
+                    s = s.encode(encoding=self.encoding, errors=self.errors)
+                self.wrappedfile.write(s)
+
+        sys.stdout = filewrapper(sys.stdout)
+
+    elif sys.version_info[1] < 6:
         import io
-        # hack sys.stdout in Windows cmd shell
         sys.stdout = io.TextIOWrapper(sys.stdout.detach(),
                                       encoding=sys.stdout.encoding,
                                       errors='ignore',
                                       line_buffering=True)
 
-    logging.basicConfig(handlers=[ColorHandler()])
-else:
-    if sys.platform.startswith('win'):
-        import __builtin__
-        # hack print function in Windows cmd shell
-        def _get_print_kwarg(kwargs, name,
-                             kwdict={'sep': ' ', 'end': '\n'},
-                             allowed_type=(str, unicode)):
-            arg = kwargs.get(name)
-            if arg is None:
-                return kwdict[name]
-            elif not isinstance(arg, allowed_type):
-                raise TypeError('%s must be None, str or unicode, not %s' %
-                                (name, str(type(arg)).split("'")[1]))
 
-        def print(*args, **kwargs):
-            sep = _get_print_kwarg(kwargs, 'sep')
-            end = _get_print_kwarg(kwargs, 'end')
-            stdout = sys.stdout
-            file = kwargs.get('file')
-            if file is None:
-                file = stdout
-            l = len(args)
-            for i in xrange(l):
-                arg = args[i]
-                if isinstance(arg, str):
-                    pass
-                elif isinstance(arg, unicode):
-                    if file is stdout:
-                        arg = arg.encode(file.encoding, 'ignore')
-                    else:
-                        arg = arg.encode(file.encoding)
-                else:
-                    arg = str(arg)
-                file.write(arg)
-                if i + 1 < l:
-                    file.write(sep)
-            file.write(end)
-        __builtin__.print = print
+from .util.log import ColorHandler
+import logging
 
+if sys.version_info[0] < 3:
     logging.root.addHandler(ColorHandler())
+else:
+    logging.basicConfig(handlers=[ColorHandler()])

--- a/ykdl/util/log.py
+++ b/ykdl/util/log.py
@@ -12,6 +12,15 @@ IS_ANSI_TERMINAL = os.getenv('TERM') in (
     'vt100',
     'xterm')
 
+if os.name == 'nt':
+    try:
+        import colorama
+    except ImportError:
+        pass
+    else:
+        colorama.init()
+        IS_ANSI_TERMINAL = True
+
 # ANSI escape code
 # See <http://en.wikipedia.org/wiki/ANSI_escape_code>
 RESET = 0
@@ -69,7 +78,7 @@ _LOG_COLOR_MAP_ = {
     logging.ERROR    : RED,
     logging.WARNING  : YELLOW,
     logging.INFO     : BLUE,
-    logging.DEBUG    : LIGHT_GRAY,
+    logging.DEBUG    : GREEN,
     logging.NOTSET   : DEFAULT }
 
 _colorFormatter = logging.Formatter("\33[%(color)sm%(levelname)s:%(name)s:%(message)s\33[0m")
@@ -84,4 +93,3 @@ class ColorHandler(logging.StreamHandler):
         if IS_ANSI_TERMINAL:
             recode.color = _LOG_COLOR_MAP_[recode.levelno]
         return logging.StreamHandler.format(self, recode)
-    


### PR DESCRIPTION
1. 使用 [colorama](https://github.com/tartley/colorama) 为 Windows shell 添加 ANSI 转义支持（不完整）
1. 顺便修改了 DEBUG 颜色为 green
1. 再顺便改进了 python2 打印时忽略 UnicodeEncodeError 的方法