### PR TITLE
Make lots of improvements for jsengine

### DIFF
--- a/ykdl/util/jsengine.py
+++ b/ykdl/util/jsengine.py
@@ -113,7 +113,7 @@ injected_script = '''\
 var exports = undefined;
 (function(program, execJS) { execJS(program) })(
 function() {
-    return #{encoded_source};
+    #{encoded_source}
 },
 function(program) {
     var print = (this.print === undefined) ? console.log : this.print;
@@ -261,10 +261,8 @@ class ExternalJSEngine(AbstractJSEngine):
         source = encode_unicode_codepoints(source)
         data = json.dumps(code)
         encoded_source = '''\
-        (function() {{
-            {source}
-            return eval({data});
-        }})()'''.format(source=source, data=data)
+        {source}
+        return eval({data});'''.format(source=source, data=data)
         return injected_script.replace('#{encoded_source}', encoded_source)
 
 


### PR DESCRIPTION
1. Now, really support unicode.
1. Reduce redundant Javascript interpreter calls.
1. Move ChakraJSEngine result value conversion code, and replaced to better conversion method.

Windows 环境，ChakraCore、jsshell 、 Node，py2/3 测试均通过。
请测试 Windows 自带的 Chakra 和 其它系统。