### PR TITLE
util.jsengine: improve interpreters compatibility

### DIFF
--- a/ykdl/util/jsengine.py
+++ b/ykdl/util/jsengine.py
@@ -160,7 +160,7 @@ if (typeof print === 'undefined' && typeof console === 'object') {
 '''
 init_global_script = u'''\
 if (typeof global === 'undefined') {
-    if (typeof Proxy === 'object') {
+    if (typeof Proxy === 'function') {
         global = new Proxy(this, {});
     } else {
         global = this;
@@ -267,7 +267,7 @@ class InternalJSEngine(AbstractJSEngine):
         return u'\n'.join(self._source)
 
     def _append(self, code):
-        self._context.eval(code, eval=False)
+        self._context.eval(code, eval=False, raw=True)
 
     def _eval(self, code):
         return self._context.eval(code)

--- a/ykdl/util/jsengine.py
+++ b/ykdl/util/jsengine.py
@@ -6,14 +6,14 @@
 
     Description:
         This library wraps the system's built-in Javascript interpreter to python.
-        It also support PyChakra.
+        It also support PyChakra, QuickJS and Node.js.
 
     Platform:
         macOS:   Use JavascriptCore
-        Linux:   Use gjs on Gnome, cjs on Cinnamon or NodeJS if installed
-        Windows: Use Win10's built-in Chakra, if not available use NodeJS
+        Linux:   Use Gjs on Gnome, CJS on Cinnamon
+        Windows: Use Chakra
 
-        PyChakra can run in all the above.
+        PyChakra, QuickJS and Node.js can run in all the above.
 
     Usage:
 
@@ -55,13 +55,10 @@ except ImportError:
     from distutils.spawn import find_executable as which
 
 
-__all__ = ['ProgramError', 'ChakraJSEngine', 'ExternalJSEngine', 'JSEngine']
+### Before using this library, check JSEngine first!!!
+__all__ = ['ProgramError', 'ChakraJSEngine', 'QuickJSEngine', 'ExternalJSEngine', 'JSEngine']
 
 
-### Before using this library, check this variable first!!!
-# **DEPRECATED**
-# Now, we check JSEngine directly.
-javascript_is_supported = True
 
 # Exceptions
 class ProgramError(Exception):
@@ -70,20 +67,31 @@ class ProgramError(Exception):
 
 ### Detect javascript interpreters
 chakra_available = False
-interpreter = None
+quickjs_available = False
+external_interpreter = None
+external_interpreter_tempfile = False
 
 # PyChakra
 try:
     from PyChakra import Runtime as ChakraHandle, get_lib_path
-    get_lib_path()
+    if not os.path.exists(get_lib_path()):
+        raise RuntimeError
 except (ImportError, RuntimeError):
     pass
 else:
     chakra_available = True
 
+# PyQuickJS
+try:
+    import quickjs
+except ImportError:
+    pass
+else:
+    quickjs_available = True
+
 # macOS: built-in JavaScriptCore
 if platform.system() == 'Darwin':
-    interpreter = '/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/jsc'
+    external_interpreter = '/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/jsc'
 
 # Windows: built-in Chakra, Node.js if installed
 elif platform.system() == 'Windows':
@@ -93,28 +101,25 @@ elif platform.system() == 'Windows':
         except ImportError:
             from .jsengine_chakra import ChakraHandle, chakra_available
 
-    interpreter = which('node')
+    external_interpreter = which('node')
 
-    if not chakra_available and interpreter is None:
+    if not chakra_available and not quickjs_available and external_interpreter is None:
         print('Please install PyChakra or Node.js!', file=sys.stderr)
-        javascript_is_supported = False
 
-# Linux: gjs on Gnome, cjs on Cinnamon or JavaScriptCore/NodeJS if installed
+# Linux: Gjs on Gnome, CJS on Cinnamon or JavaScriptCore/Node.js if installed
 elif platform.system() == 'Linux':
-    for interpreter in ('gjs', 'cjs', 'jsc', 'nodejs', 'node'):
-        interpreter = which(interpreter)
-        if interpreter:
+    for interpreter in ('gjs', 'cjs', 'jsc', 'qjs', 'nodejs', 'node'):
+        external_interpreter = which(interpreter)
+        if external_interpreter:
             break
 
-    if not chakra_available and interpreter is None:
+    if not chakra_available and not quickjs_available and external_interpreter is None:
         print('Please install at least one of the following Javascript interpreter'
-              ': PyChakra, gjs, cjs, jsc, nodejs', file=sys.stderr)
-        javascript_is_supported = False
+              ': PyChakra, Gjs, CJS, JavaScriptCore, Node.js.', file=sys.stderr)
 
 else:
-    print('Sorry, the Javascript engine is currently not supported on your system',
+    print('Sorry, the Javascript engine is currently not supported on your system.',
           file=sys.stderr)
-    javascript_is_supported = False
 
 
 # Inject to the script to let it return jsonlized value to python
@@ -144,15 +149,19 @@ if (typeof print === 'undefined' && typeof console === 'object') {
 '''
 init_global_script = u'''\
 if (typeof global === 'undefined') {
-    global = new Proxy(this, {});
+    if (typeof Proxy === 'object') {
+        global = new Proxy(this, {});
+    } else {
+        global = this;
+    }
 }
 '''
-init_del_gvar_script = u'''\
-if (typeof {gvar} === 'object') {{
-    {gvar} = undefined;
+init_del_gobject_script = u'''\
+if (typeof {gobject} === 'object') {{
+    {gobject} = undefined;
 }}
 '''
-init_del_gvars = ['exports']
+init_del_gobjects = ['exports']
 
 end_split_char = set(u';)}')
 
@@ -187,22 +196,23 @@ json_encoder = json.JSONEncoder(
 
 
 class AbstractJSEngine:
-    def __init__(self, source=u'', init_global=True, init_del_gvars=init_del_gvars):
+    def __init__(self, source=u'', init_global=True, init_del_gobjects=init_del_gobjects):
         self._source = []
         init_script = [init_print_script]
         if init_global:
             init_script.append(init_global_script)
-        if init_del_gvars:
-            for gvar in init_del_gvars:
-                if gvar == 'print' and hasattr(self, '_tempfile'):
+        if init_del_gobjects:
+            for gobject in init_del_gobjects:
+                if gobject == 'print' and hasattr(self, '_tempfile'):
                     continue
-                init_script.append(init_del_gvar_script.format(gvar=gvar))
+                init_script.append(init_del_gobject_script.format(gobject=gobject))
         init_script = u''.join(init_script)
         self.append(init_script)
         self.append(source)
 
     @property
     def source(self):
+        '''All the inputted Javascript code.'''
         return self._get_source()
 
     def _append_source(self, code):
@@ -220,62 +230,119 @@ class AbstractJSEngine:
             return code
 
     def append(self, code):
+        '''Run Javascript code and return none.'''
         code = self._check_code(code)
         if code:
             self._append(code)
 
     def eval(self, code):
+        '''Run Javascript code and return result.'''
         code = self._check_code(code)
         if code:
             return self._eval(code)
 
     def call(self, identifier, *args):
+        '''Use name string and arguments to call Javascript function.'''
         chunks = json_encoder.iterencode(args, _one_shot=True)
         chunks = [to_unicode(chunk) for chunk in chunks]
         args = u''.join(chunks)[1:-1]
         code = u'{identifier}({args})'.format(identifier=identifier, args=args)
         return self._eval(code)
 
-
-class ChakraJSEngine(AbstractJSEngine):
-    def __init__(self, source=u''):
-        if not chakra_available:
-            msg = 'No supported chakra binary found on your system!'
-            if interpreter:
-                msg += 'Please install PyChakra or use ExternalJSEngine.'
-            raise RuntimeError(msg)
-        self.chakra = ChakraHandle()
-        AbstractJSEngine.__init__(self, source)
+class InternalJSEngine(AbstractJSEngine):
+    '''Wrappered for Internal(DLL) Javascript interpreter.'''
 
     def _get_source(self):
         return u'\n'.join(self._source)
 
     def _append(self, code):
-        self._append_source(code)
-        ok, result = self.chakra.eval(code, True)
-        if not ok:
-            raise ProgramError(str(result))
+        self._context.eval(code, eval=False)
 
     def _eval(self, code):
-        self._append_source(code)
-        ok, result = self.chakra.eval(code)
-        if ok:
-            return result
-        else:
-            raise ProgramError(str(result))
+        return self._context.eval(code)
+
+
+class ChakraJSEngine(InternalJSEngine):
+    '''Wrappered for system's built-in Chakra or PyChakra(ChakraCore).'''
+
+    def __init__(self, source=u''):
+        if not chakra_available:
+            msg = 'No supported Chakra binary found on your system!'
+            if quickjs_available:
+                msg += ' Please install PyChakra or use QuickJSEngine.'
+            elif external_interpreter:
+                msg += ' Please install PyChakra or use ExternalJSEngine.'
+            else:
+                msg += ' Please install PyChakra.'
+            raise RuntimeError(msg)
+        self._context = self.Context(self)
+        InternalJSEngine.__init__(self, source)
+
+    class Context:
+        def __init__(self, engine):
+            self._engine = engine
+            self._context = ChakraHandle()
+
+        def eval(self, code, eval=True, raw=False):
+            self._engine._append_source(code)
+            ok, result = self._context.eval(code, raw=raw)
+            if ok:
+                if eval:
+                    return result
+            else:
+                raise ProgramError(str(result))
+
+
+class QuickJSEngine(InternalJSEngine):
+    '''Wrappered for QuickJS python binding quickjs.'''
+
+    def __init__(self, source=u''):
+        if not quickjs_available:
+            msg = 'No supported QuickJS package found on custom python environment!'
+            if chakra_available:
+                msg += ' Please install python package quickjs or use ChakraJSEngine.'
+            elif external_interpreter:
+                msg += ' Please install python package quickjs or use ExternalJSEngine.'
+            else:
+                msg += ' Please install python package quickjs.'
+            raise RuntimeError(msg)
+        self._context = self.Context(self)
+        InternalJSEngine.__init__(self, source)
+
+    class Context:
+        def __init__(self, engine):
+            self._engine = engine
+            self._context = quickjs.Context()
+
+        def eval(self, code, eval=True, raw=False):
+            self._engine._append_source(code)
+            try:
+                result = self._context.eval(code)
+            except quickjs.JSException as e:
+                raise ProgramError(*e.args)
+            else:
+                if eval:
+                    if raw or not isinstance(result, quickjs.Object):
+                        return result
+                    else:
+                        return json.loads(result.json())
 
 
 class ExternalJSEngine(AbstractJSEngine):
+    '''Wrappered for external Javascript interpreter.'''
+
     def __init__(self, source=u''):
-        if not interpreter:
+        if not external_interpreter:
+            msg = 'No supported external Javascript interpreter found on your system!'
             if chakra_available:
-                msg = ('ExternalJSEngine is not available now! Please install '
-                       'a Javascript interpreter or use ChakraJSEngine.')
+                msg += (' Please install one or use ChakraJSEngine.')
+            elif quickjs_available:
+                msg += (' Please install one or use QuickJSEngine.')
             else:
-                msg = 'No supported Javascript interpreter found on your system!'
+                msg += (' Please install one.')
             raise RuntimeError(msg)
         self._last_code = u''
-        self._tempfile = False
+        self._tempfile = external_interpreter_tempfile
         AbstractJSEngine.__init__(self, source)
 
     def _get_source(self, last_code=True):
@@ -311,25 +378,26 @@ class ExternalJSEngine(AbstractJSEngine):
         else:
             raise ProgramError(result)
 
-    def _run_interpreter(self, cmd, stdin=None, input=None):
+    def _run_interpreter(self, cmd, input=None):
         p = None
+        stdin = PIPE if input else None
         try:
             p = Popen(cmd, stdin=stdin, stdout=PIPE, stderr=PIPE)
-            stdoutdata, stderrdata = p.communicate(input=input)
-            ret = p.wait()
+            stdout_data, stderr_data = p.communicate(input=input)
+            retcode = p.wait()
         finally:
             del p
-        if ret != 0:
+        if retcode != 0:
             raise RuntimeError('Javascript interpreter returns non-zero value! '
-                               'Error msg: %s' % stderrdata.decode('utf8'))
+                               'Error msg: %s' % stderr_data.decode('utf8'))
         # Output unicode
-        return stdoutdata.decode('utf8')
+        return stdout_data.decode('utf8')
 
     def _run_interpreter_with_pipe(self, code):
-        cmd = [interpreter]
+        cmd = [external_interpreter]
         # Input bytes
         code = to_bytes(code)
-        return self._run_interpreter(cmd, stdin=PIPE, input=code)
+        return self._run_interpreter(cmd, input=code)
 
     def _run_interpreter_with_tempfile(self, code):
         (fd, filename) = tempfile.mkstemp(prefix='execjs', suffix='.js')
@@ -340,7 +408,7 @@ class ExternalJSEngine(AbstractJSEngine):
             with io.open(filename, 'wb') as fp:
                 fp.write(code)
 
-            cmd = [interpreter, filename]
+            cmd = [external_interpreter, filename]
             return self._run_interpreter(cmd)
         finally:
             os.remove(filename)
@@ -351,21 +419,47 @@ class ExternalJSEngine(AbstractJSEngine):
         return injected_script.format(source=source, data=data)
 
 
-# Prefer ChakraJSEngine (via dynamic library loading)
+def set_external_interpreter(interpreter):
+    global external_interpreter
+    external_interpreter = which(interpreter)
+    if external_interpreter is None:
+        print("Can not find given interpreter's path: %r" % interpreter, file=sys.stderr)
+    else:
+        set_external_interpreter_tempfile()
+
+
+def set_external_interpreter_tempfile():
+    global external_interpreter_tempfile
+    interpreter_name = os.path.basename(external_interpreter).split('.')[0]
+    external_interpreter_tempfile = interpreter_name in ('qjs', 'd8')
+
+
+if external_interpreter:
+    set_external_interpreter_tempfile()
+
+
+# Prefer ChakraJSEngine & QuickJSEngine (via dynamic library loading)
 if chakra_available:
     JSEngine = ChakraJSEngine
-elif javascript_is_supported:
+elif quickjs_available:
+    JSEngine = QuickJSEngine
+elif external_interpreter:
     JSEngine = ExternalJSEngine
 else:
     JSEngine = None
 
 
 if __name__ == '__main__':
-    #interpreter = 'S:/jsshell-win64/js'
-    #interpreter = 'S:/node/node'
-    for JSEngine in (ChakraJSEngine, ExternalJSEngine):
+    #set_external_interpreter('S:/jsshell-win64/js.exe')
+    #set_external_interpreter('S:/node/node.exe')
+    #set_external_interpreter('S:/quickjs-2019-10-27-win64/qjs.exe')
+    #set_external_interpreter('S:/hermes-cli-windows-v0.3.0/hermes.exe')
+    #set_external_interpreter('S:/v8-win64-rel-8.0.354/d8.exe')
+    print('JSEngine is %r' % JSEngine)
+    print('external_interpreter is %r' % external_interpreter)
+    for JSEngine in (ChakraJSEngine, QuickJSEngine, ExternalJSEngine):
         try:
-            print('start test %s:' % JSEngine.__name__)
+            print('\nStart test %s:' % JSEngine.__name__)
             ctx = JSEngine()
             assert ctx._eval('') is None, 'eval empty fail!'
             assert ctx.eval('1 + 1') == 2, 'eval fail!'
@@ -389,7 +483,7 @@ if __name__ == '__main__':
             import traceback
             traceback.print_exception(*sys.exc_info())
         finally:
-            print('end test %s' % JSEngine.__name__)
+            print('End test %s\n' % JSEngine.__name__)
     if platform.system() == 'Windows':
         import msvcrt
         msvcrt.getch()

--- a/ykdl/util/jsengine.py
+++ b/ykdl/util/jsengine.py
@@ -8,13 +8,13 @@
     This library wraps the system's built-in Javascript interpreter to python.
     It also support PyChakra, QuickJS, Node.js, etc.
 
-    If your want use other Javascript interpreters , please call
-    'set_external_interpreter' with binary's path after imported this module:
+    If your want use a special external Javascript interpreter, please call
+    `set_external_interpreter` with binary's path after imported this module:
       
       from jsengine import *
 
-      set_external_interpreter(binary_path)
-      ctx = ExternalJSEngine()
+      if set_external_interpreter(binary_path):  # setting OK
+          ctx = ExternalJSEngine()
 
   Platform:
     macOS:   Use JavascriptCore
@@ -377,10 +377,7 @@ class ExternalJSEngine(AbstractJSEngine):
                 self._tempfile = True
         if self._tempfile:
             output = self._run_interpreter_with_tempfile(code)
-        #else:
-        #    output = self._run_interpreter_with_pipe(code)
 
-        #print(output)
         output = output.replace(u'\r\n', u'\n').replace(u'\r', u'\n')
         # Search result in the last 5 lines of output
         for result_line in output.split(u'\n')[-5:]:
@@ -436,20 +433,22 @@ class ExternalJSEngine(AbstractJSEngine):
 def set_external_interpreter(interpreter):
     global external_interpreter
     external_interpreter = which(interpreter)
-    if external_interpreter is None:
-        print("Can not find the given interpreter's path: %r" % interpreter, file=sys.stderr)
+    res = external_interpreter is not None
+    if res:
+        _set_external_interpreter_tempfile()
     else:
-        set_external_interpreter_tempfile()
+        print("Can not find the given interpreter's path: %r" % interpreter, file=sys.stderr)
+    return res
 
 
-def set_external_interpreter_tempfile():
+def _set_external_interpreter_tempfile():
     global external_interpreter_tempfile
     interpreter_name = os.path.basename(external_interpreter).split('.')[0]
     external_interpreter_tempfile = interpreter_name in ('qjs', 'qjsbn', 'd8')
 
 
 if external_interpreter:
-    set_external_interpreter_tempfile()
+    _set_external_interpreter_tempfile()
 
 
 # Prefer InternalJSEngine (via dynamic library loading)

--- a/ykdl/util/jsengine_chakra.py
+++ b/ykdl/util/jsengine_chakra.py
@@ -29,6 +29,7 @@ class ChakraHandle():
 
         context = _ctypes.c_void_p()
         chakra.JsCreateContext(runtime, point(context))
+        chakra.JsSetCurrentContext(context)
 
         self.__runtime = runtime
         self.__context = context

--- a/ykdl/util/jsengine_test.py
+++ b/ykdl/util/jsengine_test.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+#-*- coding: UTF-8 -*-
+
+import unittest
+import platform
+import jsengine
+from jsengine import *
+
+
+print_source_code = False
+
+def skip(func):
+    def newfunc(*args, **kwargs):
+        global ctx
+        if ctx:
+            try:
+                func(*args, **kwargs)
+            except:
+                ctx = JSEngine()
+                raise
+    return newfunc
+
+class JSEngineES6Tests(unittest.TestCase):
+
+    expected_exceptions = ProgramError, RuntimeError
+
+    def test_00_init(self):
+        global ctx
+        ctx = JSEngine()
+
+    @skip
+    def test_01_keyword_let(self):
+        _ctx = JSEngine()
+        with self.assertRaises(self.expected_exceptions):
+            _ctx.eval('''
+            let vlet;
+            let vlet;''')
+        _ctx = JSEngine()
+        with self.assertRaises(self.expected_exceptions):
+            _ctx.eval('''
+            var vlet = 1;
+            let vlet;''')
+        self.assertEqual(ctx.eval('''
+        var vlet = 1;
+        function flet() {
+            let vlet = 2;
+        }
+        flet(), vlet'''), 1)
+
+    @skip
+    def test_02_keyword_const(self):
+        _ctx = JSEngine()
+        with self.assertRaises(self.expected_exceptions):
+            _ctx.eval('const vconst')
+        _ctx = JSEngine()
+        with self.assertRaises(self.expected_exceptions):
+            _ctx.eval('''
+            const vconst = 1;
+            const vconst = 1''')
+        _ctx = JSEngine()
+        with self.assertRaises(self.expected_exceptions):
+            _ctx.eval('''
+            const vconst = 1;
+            vconst = 1;''')
+        _ctx = JSEngine()
+        with self.assertRaises(self.expected_exceptions):
+            _ctx.eval('''
+            var vconst;
+            const vconst = 1;''')
+        self.assertEqual(ctx.eval('''
+        var vconst = 1;
+        function fconst() {
+            const vconst = 2;
+        }
+        fconst(), vconst'''), 1)
+
+    @skip
+    def test_03_operator_power(self):
+        self.assertEqual(ctx.eval('3 ** 3'), 27)
+
+    @skip
+    def test_04_keyword_for_of(self):
+        ctx.eval('for (n of []) {}')
+
+    @skip
+    def test_05_operator_spread_rest(self):
+        self.assertEqual(ctx.eval('''
+        function foo(first, ...args) {return [first, args]}
+        foo(...[1, 2, 3])'''), [1, [2, 3]])
+
+    @skip
+    def test_06_function_arrow(self):
+        ctx.eval('(()=>{})()')
+        ctx.eval('(arg => arg)(1)')
+        _ctx = JSEngine()
+        with self.assertRaises(self.expected_exceptions):
+            _ctx.eval('''
+            foo = arg => arg;
+            obj = new foo()''')
+
+    @skip
+    def test_07_function_default_arguments(self):
+        ctx.eval('function foo(agr = "default") {}')
+
+    @skip
+    def test_08_class_super(self):
+        ctx.eval('''
+        class C1 {
+            method() {return 1;}
+        }
+        var c1 = new C1()''')
+        ctx.append('''
+        class C2 extends C1 {
+            method() {return super.method();}
+        }
+        ''')
+        self.assertEqual(ctx.eval('new C2().method()'), 1)
+
+    @skip
+    def test_09_type_symbol(self):
+        ctx.eval('''
+        var sym1 = Symbol('foo');
+        var sym2 = Symbol('foo')''')
+        self.assertFalse(ctx.eval('sym1 === sym2'))
+        _ctx = JSEngine()
+        with self.assertRaises(self.expected_exceptions):
+            _ctx.eval('var sym3 = new Symbol()')
+
+    @skip
+    def test_10_type_set_map(self):
+        ctx.eval('''
+        new Set();
+        new Map();''')
+
+    @skip
+    def test_11_type_typedarray(self):
+        ctx.eval('''
+        new Int8Array(2);
+        new Uint8Array(2);
+        new Uint8ClampedArray(2);
+        new Int16Array(2);
+        new Uint16Array(2);
+        new Int32Array(2);
+        new Uint32Array(2);
+        new Float32Array(2);
+        new Float64Array(2);''')
+
+    @skip
+    def test_12_deconstruction(self):
+        ctx.eval('''
+        var arr = [1, 2, 3];
+        var [n1, n2, n3] = arr;''')
+        ctx.eval('''
+        var obj = {id1: 1, id2: 2, id3: 3}
+        var {id1, id2, id3} = obj;''')
+        ctx.eval('''
+        var [n1, n2, n3, n4] = arr;
+        var n1 = undefined;
+        var [n1] = arr;''')
+        ctx.eval('''
+        var {id1, id2, id3, id4} = obj;
+        var id1 = undefined;
+        var {id1} = obj;''')
+        self.assertEqual(ctx.eval('n1'), 1)
+        self.assertEqual(ctx.eval('n4'), None)
+        self.assertEqual(ctx.eval('id1'), 1)
+        self.assertEqual(ctx.eval('id4'), None)
+
+    @skip
+    def test_13_string_template(self):
+        self.assertEqual(ctx.eval('''
+`123
+456`'''), '123\n456')
+        self.assertEqual(ctx.eval('`123456${3 + 4}`'), '1234567')
+
+    @skip
+    def test_14_literal(self):
+        self.assertEqual(ctx.eval('0b11'), 3)
+        self.assertEqual(ctx.eval('0B11'), 3)
+        self.assertEqual(ctx.eval('0o11'), 9)
+        self.assertEqual(ctx.eval('0O11'), 9)
+
+    @skip
+    def test_98_engine_in_out_string(self):
+        self.assertEqual(ctx.eval('"es:αβγ"'), u'es:αβγ')
+        self.assertEqual(ctx.eval(u'"eu:αβγ"'), u'eu:αβγ')
+        self.assertEqual(ctx.eval(jsengine.to_bytes('"eb:αβγ"')), u'eb:αβγ')
+        ctx.append('''
+        function ping(s1, s2, s3) {
+            return [s1, s2, s3]
+        }''')
+        # Mixed string types input
+        self.assertEqual(ctx.call('ping',
+                'cs:αβγ', u'cu:αβγ', jsengine.to_bytes('cb:αβγ')),
+                [u'cs:αβγ', u'cu:αβγ', u'cb:αβγ'])
+
+    @skip
+    def test_99_engine_get_source(self):
+        if print_source_code:
+            print('\nSOURCE CODE:')
+            print(ctx.source)
+            print('SOURCE CODE END\n')
+        else:
+            ctx.source
+
+
+def test_engine(engine):
+    global JSEngine, ctx
+    engine_name = engine.__name__
+    print('\nStart test %s:' % engine_name)
+    if engine_name == 'ExternalJSEngine':
+        print('Used external_interpreter: %r' % jsengine.external_interpreter)
+    JSEngine = engine
+    ctx = None
+    unittest.TestProgram(exit=False)
+    print('End test %s\n' % engine_name)
+    
+def test_main(external_interpreters):
+    print('Default JSEngine is %r' % jsengine.JSEngine)
+    print('Default external_interpreter is %r' % jsengine.external_interpreter)
+
+    for JSEngine in (ChakraJSEngine, QuickJSEngine):
+        test_engine(JSEngine)
+
+    for external_interpreter in external_interpreters:
+        set_external_interpreter(external_interpreter)
+        if jsengine.external_interpreter:
+            test_engine(ExternalJSEngine)
+
+    if platform.system() == 'Windows':
+        import msvcrt
+        print('Press any key for continue ...')
+        msvcrt.getch()
+
+default_external_interpreters = [
+    # test passed
+    'gjs',          # Gjs
+    'cjs',          # CJS
+    'jsc',          # JavaScriptCore
+    'qjs',          # QuickJS
+    'node',         # Node.js
+    'nodejs',       # Node.js
+    'spidermonkey', # SpiderMonkey
+    'chakra',       # ChakraCore
+
+    # test passed, but unceremonious names
+    #'d8',          # V8
+    #'js',          # SpiderMonkey
+    #'ch',          # ChakraCore
+
+    # test failed
+    'hermes',       # Hermes
+    'duk',          # Duktape
+]
+
+
+if __name__ == '__main__':
+    import sys
+    try:
+        sys.argv.remove('-psc')
+    except ValueError:
+        pass
+    else:
+        print_source_code = True
+    external_interpreters = sys.argv[1:] or default_external_interpreters
+    del sys.argv[1:] # clear arguments
+    test_main(external_interpreters)


### PR DESCRIPTION
close #465

1. Add support QuickJS.
1. Fixed compatibility with Hermes, V8.
1. Add `set_external_interpreter` function to costom external interpreter.
1. Add unit test for most common ES6's features.