### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,11 +18,10 @@ this project is a fork of `you-get <https://github.com/soimort/you-get>`_ with b
 3. support Python2
 
 Consider install from source by:
-```
-sudo apt-get install ffmpeg mpv python3-pip
-pip3 install git+git://github.com/zhangn1985/ykdl.git --upgrade --user
-```
-add `~/.local/bin` to your PATH
+
+0. sudo apt-get install ffmpeg mpv python3-pip
+1. pip3 install git+git://github.com/zhangn1985/ykdl.git --upgrade --user
+2. add `~/.local/bin` to your PATH
 
 Simple installation guide:
 

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,13 @@ this project is a fork of `you-get <https://github.com/soimort/you-get>`_ with b
 2. focus on China mainland video sites
 3. support Python2
 
+Consider install from source by:
+```
+sudo apt-get install ffmpeg mpv python3-pip
+pip3 install git+git://github.com/zhangn1985/ykdl.git --upgrade --user
+```
+add `~/.local/bin` to your PATH
+
 Simple installation guide:
 
 Linux/debian:


### PR DESCRIPTION
Since the version on PyPI is really outdated and many plugins were updated during the time to support website (e.g., DouYu), added instructions to install from git source with `pip`. 