### PR TITLE
Fix bilibili when using python2

### DIFF
--- a/ykdl/extractors/bilibili/bangumi.py
+++ b/ykdl/extractors/bilibili/bangumi.py
@@ -33,15 +33,15 @@ class BiliBan(BiliBase):
         return vid, title, artist
 
     def get_api_url(self, qn):
-        params_str = urlencode({
-            'appkey': APPKEY,
-            'cid': self.vid,
-            'module': 'bangumi',
-            'platform': 'html5',
-            'player': 1,
-            'qn': qn,
-            'season_type': self.seasonType
-        })
+        params_str = urlencode([
+            ('appkey', APPKEY),
+            ('cid', self.vid),
+            ('module', 'bangumi'),
+            ('platform', 'html5'),
+            ('player', 1),
+            ('qn', qn),
+            ('season_type', self.seasonType)
+        ])
         return sign_api_url(api_url, params_str, SECRETKEY)
 
     def prepare_list(self):

--- a/ykdl/extractors/bilibili/video.py
+++ b/ykdl/extractors/bilibili/video.py
@@ -38,13 +38,13 @@ class BiliVideo(BiliBase):
         return vid, title, artist
 
     def get_api_url(self, qn):
-        params_str = urlencode({
-            'appkey': APPKEY,
-            'cid': self.vid,
-            'platform': 'html5',
-            'player': 0,
-            'qn': qn
-        })
+        params_str = urlencode([
+            ('appkey', APPKEY),
+            ('cid', self.vid),
+            ('platform', 'html5'),
+            ('player', 0),
+            ('qn', qn)
+        ])
         return sign_api_url(api_url, params_str, SECRETKEY)
 
     def prepare_list(self):


### PR DESCRIPTION
B站的API貌似对参数的顺序有要求，python3的urlencode默认会按照首字母顺序排序，python2则是打乱顺序导致解析失败，所以这里把dict换成list来指定参数顺序。