### PR TITLE
updated mpv related commandline option

### DIFF
--- a/webykdl/playthread.py
+++ b/webykdl/playthread.py
@@ -17,7 +17,7 @@ def launch_player(urls, **args):
     if args['referer']:
         cmd += ['--referrer', args['referer']]
     if args['title']:
-        cmd += ['--force-media-title', args['title']]
+        cmd += ['--force-media-title=' + args['title']]
     if args['header']:
         cmd += ['--http-header-fields', args['header']]
     cmd += list(urls)

--- a/webykdl/playthread.py
+++ b/webykdl/playthread.py
@@ -13,13 +13,13 @@ def launch_player(urls, **args):
     if len(urls) > 1:
         cmd += ['--merge-files']
     if args['ua']:
-        cmd += ['--user-agent', args['ua']]
+        cmd += ['--user-agent=' + args['ua']]
     if args['referer']:
-        cmd += ['--referrer', args['referer']]
+        cmd += ['--referrer=' + args['referer']]
     if args['title']:
         cmd += ['--force-media-title=' + args['title']]
     if args['header']:
-        cmd += ['--http-header-fields', args['header']]
+        cmd += ['--http-header-fields=' + args['header']]
     cmd += list(urls)
     return subprocess.Popen(cmd)
 

--- a/ykdl/util/wrap.py
+++ b/ykdl/util/wrap.py
@@ -32,7 +32,7 @@ def launch_player(player, urls, ext, **args):
 
     if 'mpv' in cmd[0]:
         if ext == 'm3u8' and any(os.path.isfile(url) for url in urls):
-            cmd += ['--demuxer-lavf-o', 'protocol_whitelist=[file,http,https,tls,rtp,tcp,udp,crypto,httpproxy]']
+            cmd += ['--demuxer-lavf-o=' + 'protocol_whitelist=[file,http,https,tls,rtp,tcp,udp,crypto,httpproxy]']
         if args['ua']:
             cmd += ['--user-agent=' + args['ua']]
         if args['referer']:

--- a/ykdl/util/wrap.py
+++ b/ykdl/util/wrap.py
@@ -34,13 +34,13 @@ def launch_player(player, urls, ext, **args):
         if ext == 'm3u8' and any(os.path.isfile(url) for url in urls):
             cmd += ['--demuxer-lavf-o', 'protocol_whitelist=[file,http,https,tls,rtp,tcp,udp,crypto,httpproxy]']
         if args['ua']:
-            cmd += ['--user-agent', args['ua']]
+            cmd += ['--user-agent=' + args['ua']]
         if args['referer']:
-            cmd += ['--referrer', args['referer']]
+            cmd += ['--referrer=' + args['referer']]
         if args['title']:
             cmd += ['--force-media-title=' + encode_for_wrap(args['title'], 'ignore')]
         if args['header']:
-            cmd += ['--http-header-fields', args['header']]
+            cmd += ['--http-header-fields=' + args['header']]
 
     urls = [encode_for_wrap(url) for url in urls]
     if args['rangefetch']:

--- a/ykdl/util/wrap.py
+++ b/ykdl/util/wrap.py
@@ -32,7 +32,7 @@ def launch_player(player, urls, ext, **args):
 
     if 'mpv' in cmd[0]:
         if ext == 'm3u8' and any(os.path.isfile(url) for url in urls):
-            cmd += ['--demuxer-lavf-o=' + 'protocol_whitelist=[file,http,https,tls,rtp,tcp,udp,crypto,httpproxy]']
+            cmd += ['--demuxer-lavf-o=protocol_whitelist=[file,http,https,tls,rtp,tcp,udp,crypto,httpproxy]']
         if args['ua']:
             cmd += ['--user-agent=' + args['ua']]
         if args['referer']:

--- a/ykdl/util/wrap.py
+++ b/ykdl/util/wrap.py
@@ -38,7 +38,7 @@ def launch_player(player, urls, ext, **args):
         if args['referer']:
             cmd += ['--referrer', args['referer']]
         if args['title']:
-            cmd += ['--force-media-title', encode_for_wrap(args['title'], 'ignore')]
+            cmd += ['--force-media-title=' + encode_for_wrap(args['title'], 'ignore')]
         if args['header']:
             cmd += ['--http-header-fields', args['header']]
 


### PR DESCRIPTION
Since the new mpv release (0.32.0) parsing for some command line options has been changed. 

More specifically, the option `force-media-title` is affected and needs to be changed to `--force-media-title=[media-title]` instead of the old format `--force-media-title [media-title]`

The updated version has been tested on Arch Linux.